### PR TITLE
Updating version of mitmproxy to 0.18.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
         'Programming Language :: Python :: 2.7',
     ],
     packages=find_packages(),
-    install_requires=['mitmproxy==0.17',
+    install_requires=['mitmproxy==0.18.1',
                       'Flask<0.11,>=0.10.1',
                       'pyYAML==3.11',
                       'jsonschema==2.5',


### PR DESCRIPTION
Hello , 

I tried setting up mastermind project using "pip install", but I got 
"
Collecting mitmproxy==0.17
  Could not find a version that satisfies the requirement mitmproxy==0.17 (from versions: 0.8, 0.8.1, 0.9, 0.9.1, 0.9.2, 0.10, 0.10.1, 0.11, 0.11.1, 0.11.2, 0.11.3, 0.12.0, 0.12.1, 0.13, 0.14.0, 0.15, 0.18.1, 0.18.2, 0.18.3, 1.0.0, 1.0.1, 1.0.2, 2.0.0)
No matching distribution found for mitmproxy==0.17
"
So upgrading the version to 0.18.1

It can also be verified by just trying to run "pip install mitmproxy==0.17"
"pip install mitmproxy==0.18.1"